### PR TITLE
Allow running on newer versions of Terraform

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ module "nessus" {
                                cidr_blocks = []
                              }
                            }
-  nessus_key             = "dloiijfhqoiewrubfoqieuurbfcpoiqweunrcopiqeuhnrfpoiu13ehrwft"
   tags          = {
                     Terraform = "true"
                     Environment = "development"

--- a/main.tf
+++ b/main.tf
@@ -182,6 +182,11 @@ resource "aws_launch_configuration" "this" {
   associate_public_ip_address = var.associate_public_ip_address
   user_data                   = local.userdata
 
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "required"
+  }
+
   lifecycle {
     create_before_destroy = true
   }

--- a/main.tf
+++ b/main.tf
@@ -142,20 +142,6 @@ data "aws_ami" "this" {
 #-----------------------------------
 # Deploy Nessus Instance
 #-----------------------------------
-locals {
-  tags_asg_format = null_resource.tags_as_list_of_maps.*.triggers
-}
-
-resource "null_resource" "tags_as_list_of_maps" {
-  count = length(keys(var.tags))
-
-  triggers = {
-    "key"                 = keys(var.tags)[count.index]
-    "value"               = values(var.tags)[count.index]
-    "propagate_at_launch" = "true"
-  }
-}
-
 resource "aws_autoscaling_group" "this" {
   name                      = var.name
   min_size                  = 1
@@ -170,16 +156,20 @@ resource "aws_autoscaling_group" "this" {
     create_before_destroy = true
   }
 
-  tags = concat(
-    [
-      {
-        key                 = "Name"
-        value               = var.name
-        propagate_at_launch = true
-      }
-    ],
-    local.tags_asg_format,
-  )
+  tag {
+    key                 = "Name"
+    value               = var.name
+    propagate_at_launch = true
+  }
+
+  dynamic "tag" {
+    for_each = var.tags
+    content {
+      key                 = tag.value.key
+      propagate_at_launch = true
+      value               = tag.value.value
+    }
+  }
 }
 
 resource "aws_launch_configuration" "this" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,10 @@
 terraform {
-  required_version = ">= 0.15.1, < 1.2"
+  required_version = "~> 1.2"
 
   required_providers {
-    aws = "~>3.0"
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
   }
 }


### PR DESCRIPTION
Hey,

I was just about to give this module a whirl when I realized it's pinned against pretty old versions.  I just bumped it to let those of us on newer versions use it.  I haven't run my fork yet, but it did pass a `terraform validate` with no warnings.